### PR TITLE
Fix repo location for goconvey

### DIFF
--- a/cmd/addzid/ignored_test.go
+++ b/cmd/addzid/ignored_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test911AddZidIgnoresUnserializedFields(t *testing.T) {

--- a/cmd/addzid/map_test.go
+++ b/cmd/addzid/map_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test910MapAddZid(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/annot_test.go
+++ b/cmd/addzid/old_bambam_tests/annot_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCommentAnnotationWorks(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/capidtag_test.go
+++ b/cmd/addzid/old_bambam_tests/capidtag_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestZidTagOrderAssignment(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/cpfile_test.go
+++ b/cmd/addzid/old_bambam_tests/cpfile_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCpCopiesFilesIntoDirHier(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/diff_test.go
+++ b/cmd/addzid/old_bambam_tests/diff_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestDiffB(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/doubleslice_test.go
+++ b/cmd/addzid/old_bambam_tests/doubleslice_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test002SlistSliceIntToListListInt64(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/go2cpType_test.go
+++ b/cmd/addzid/old_bambam_tests/go2cpType_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test001GoToCapTypeConversion(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/list_test.go
+++ b/cmd/addzid/old_bambam_tests/list_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test005SliceOfStringToListOfText(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/listlist_test.go
+++ b/cmd/addzid/old_bambam_tests/listlist_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test010ListListStruct(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/marshal_test.go
+++ b/cmd/addzid/old_bambam_tests/marshal_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCapnpStructNaming(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/nested_test.go
+++ b/cmd/addzid/old_bambam_tests/nested_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNestedStructs016(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/order_test.go
+++ b/cmd/addzid/old_bambam_tests/order_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestOrderOfDeclIrrel(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/ptr_test.go
+++ b/cmd/addzid/old_bambam_tests/ptr_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestPointerInStruct(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/save_test.go
+++ b/cmd/addzid/old_bambam_tests/save_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test006Save1(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/singleslice_test.go
+++ b/cmd/addzid/old_bambam_tests/singleslice_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func Test004SingleSlice(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/skip_test.go
+++ b/cmd/addzid/old_bambam_tests/skip_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestZidSkip(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/slice_test.go
+++ b/cmd/addzid/old_bambam_tests/slice_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSliceToList(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/struct1_test.go
+++ b/cmd/addzid/old_bambam_tests/struct1_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 type EmptyStruct struct {

--- a/cmd/addzid/old_bambam_tests/types_test.go
+++ b/cmd/addzid/old_bambam_tests/types_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestBasicTypesInStruct(t *testing.T) {

--- a/cmd/addzid/old_bambam_tests/under_test.go
+++ b/cmd/addzid/old_bambam_tests/under_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnderScoreFieldNamesRenamed(t *testing.T) {

--- a/cmd/addzid/time_test.go
+++ b/cmd/addzid/time_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 )
 
 // run 'addzid -unexported' to see zid being added.

--- a/parse/getast_test.go
+++ b/parse/getast_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sort"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 	"github.com/glycerine/greenpack/cfg"
 	"github.com/glycerine/greenpack/gen"
 	"testing"

--- a/testdata/omitclue_test.go
+++ b/testdata/omitclue_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 	"github.com/glycerine/greenpack/msgp"
 )
 

--- a/testdata/struct_reuse_test.go
+++ b/testdata/struct_reuse_test.go
@@ -4,7 +4,7 @@ import (
 	//"fmt"
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 	"github.com/glycerine/greenpack/msgp"
 )
 

--- a/testdata/tupledefault_test.go
+++ b/testdata/tupledefault_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	cv "github.com/glycerine/goconvey/convey"
+	cv "github.com/smartystreets/goconvey/convey"
 	"github.com/glycerine/greenpack/msgp"
 )
 


### PR DESCRIPTION
glycerine/goconvey have been relocated to smartystreets/goconvey. Unfortunately a number of glycerine repos still have code dependency to the deprecated goconvey URL. This is to fix that.